### PR TITLE
fix: resolve CI build failures across all modules

### DIFF
--- a/wallet-common/build.gradle
+++ b/wallet-common/build.gradle
@@ -1,6 +1,10 @@
+apply plugin: 'java-library'
+
 bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
-    implementation project(":wallet-entity")
+    api project(":wallet-entity")
+    implementation 'commons-codec:commons-codec:1.16.0'
+    implementation 'org.bitcoinj:bitcoinj-core:0.14.7'
 }

--- a/wallet-common/src/main/kotlin/com/wallet/biz/config/RestTemplateConfig.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/config/RestTemplateConfig.kt
@@ -14,8 +14,8 @@ open class RestTemplateConfig {
     @Bean
     open fun rest(restTemplateBuilder: RestTemplateBuilder): RestTemplate {
         val restTemplate = restTemplateBuilder
-            .connectTimeout(Duration.ofSeconds(10))
-            .readTimeout(Duration.ofSeconds(30))
+            .setConnectTimeout(Duration.ofSeconds(10))
+            .setReadTimeout(Duration.ofSeconds(30))
             .build()
         restTemplate.messageConverters.add(OctetStreamJsonConverter())
         return restTemplate

--- a/wallet-common/src/main/kotlin/com/wallet/biz/mq/PushComponent.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/mq/PushComponent.kt
@@ -21,7 +21,7 @@ class PushComponent : LogService() {
 
     private fun getEncryptionKey(): String {
         return pushEncryptionKey
-            ?: throw BizException(ErrorCode.ERROR_PARAM, "Push encryption key not configured (wallet.crypto.push-key)")
+            ?: throw BizException(ErrorCode.ERROR_PARAM.code, "Push encryption key not configured (wallet.crypto.push-key)")
     }
 
     fun sendMsgToMq(msg: String) {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/rpc/TrxApi.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/rpc/TrxApi.kt
@@ -64,7 +64,15 @@ class TrxApi(val url: String, val restTemplate: RestTemplate) {
         val sBytes = signature.s.toByteArray()
         System.arraycopy(rBytes, Math.max(0, rBytes.size - 32), sigBytes, Math.max(0, 32 - rBytes.size), Math.min(32, rBytes.size))
         System.arraycopy(sBytes, Math.max(0, sBytes.size - 32), sigBytes, Math.max(0, 64 - sBytes.size), Math.min(32, sBytes.size))
-        sigBytes[64] = ecKey.findRecoveryId(org.bitcoinj.core.Sha256Hash.wrap(txIdBytes), signature).toByte()
+        var recId = -1
+        for (i in 0..3) {
+            val recovered = org.bitcoinj.core.ECKey.recoverFromSignature(i, signature, org.bitcoinj.core.Sha256Hash.wrap(txIdBytes), false)
+            if (recovered != null && recovered.pubKeyPoint == ecKey.pubKeyPoint) {
+                recId = i
+                break
+            }
+        }
+        sigBytes[64] = recId.toByte()
 
         val signatureHex = NumericUtil.bytesToHex(sigBytes)
 

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/AddressAdminServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/AddressAdminServiceImpl.kt
@@ -37,17 +37,17 @@ class AddressAdminServiceImpl: AddressAdminService {
     }
 
     override fun del(id: Long) {
-        addressAdminRepository.delete(id)
+        addressAdminRepository.deleteById(id)
     }
 
     override fun update(addressAdmin: AddressAdmin) {
-        val e = addressAdminRepository.findOne(addressAdmin.id)
+        val e = addressAdminRepository.findById(addressAdmin.id).orElse(null)
         BasicUtils.copyPropertiesIgnoreNull(addressAdmin, e)
         addressAdminRepository.save(e)
     }
 
     override fun getById(id:Long): AddressAdmin? {
-        return addressAdminRepository.findOne(id)
+        return addressAdminRepository.findById(id).orElse(null)
     }
 
     override fun save(addressAdmin:AddressAdmin): AddressAdmin {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/AddressServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/AddressServiceImpl.kt
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class AddressServiceImpl: AddressService {
 
     override fun delete(id: Long) {
-        addressRepository.delete(id)
+        addressRepository.deleteById(id)
     }
 
     override fun findAllBitcoinFork(): List<Address> {
@@ -47,7 +47,7 @@ class AddressServiceImpl: AddressService {
     }
 
     override fun saveAll(list: List<Address>): List<Address> {
-        return addressRepository.save(list)
+        return addressRepository.saveAll(list)
     }
 
     override fun findByType(chainType: String?): List<Address> {
@@ -62,7 +62,7 @@ class AddressServiceImpl: AddressService {
     }
 
     override fun getById(id:Long): Address? {
-        return addressRepository.findOne(id)
+        return addressRepository.findById(id).orElse(null)
     }
 
     override fun save(address:Address): Address {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/BlockHeightServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/BlockHeightServiceImpl.kt
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class BlockHeightServiceImpl: BlockHeightService {
 
     override fun getById(id:Long): BlockHeight? {
-        return blockHeightRepository.findOne(id)
+        return blockHeightRepository.findById(id).orElse(null)
     }
 
     override fun save(blockHeight:BlockHeight): BlockHeight {
@@ -33,13 +33,13 @@ class BlockHeightServiceImpl: BlockHeightService {
     }
 
     override fun update(blockHeight: BlockHeight) {
-        val e=blockHeightRepository.findOne(blockHeight.id)
+        val e=blockHeightRepository.findById(blockHeight.id).orElse(null)
         BasicUtils.copyPropertiesIgnoreNull(blockHeight,e)
         blockHeightRepository.save(e)
     }
 
     override fun del(id: Long) {
-        blockHeightRepository.delete(id)
+        blockHeightRepository.deleteById(id)
     }
 
     @Autowired lateinit var blockHeightRepository: BlockHeightRepository

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/ConfigServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/ConfigServiceImpl.kt
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class ConfigServiceImpl: ConfigService {
 
     override fun getById(id:Long): Config? {
-        return configRepository.findOne(id)
+        return configRepository.findById(id).orElse(null)
     }
 
     override fun save(config:Config): Config {
@@ -33,13 +33,13 @@ class ConfigServiceImpl: ConfigService {
     }
 
     override fun update(config: Config) {
-        val e=configRepository.findOne(config.id)
+        val e=configRepository.findById(config.id).orElse(null)
         BasicUtils.copyPropertiesIgnoreNull(config,e)
         configRepository.save(e)
     }
 
     override fun del(id: Long) {
-        configRepository.delete(id)
+        configRepository.deleteById(id)
     }
 
     @Autowired lateinit var configRepository: ConfigRepository

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/DepositServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/DepositServiceImpl.kt
@@ -19,7 +19,7 @@ class DepositServiceImpl: DepositService {
     }
 
     override fun saveAll(list: List<Deposit>): List<Deposit> {
-        return depositRepository.save(list)
+        return depositRepository.saveAll(list)
     }
 
     override fun getByIsUpload(isUpload: Int): List<Deposit> {
@@ -53,11 +53,11 @@ class DepositServiceImpl: DepositService {
             pre=pre.and(QDeposit.deposit.tokenSymbol.eq(entity.tokenSymbol))
         if(entity.chainType!=null)
             pre=pre.and(QDeposit.deposit.chainType.eq(entity.chainType))
-        return depositRepository.findAll(pre, PageRequest(find.page, find.size))
+        return depositRepository.findAll(pre, PageRequest.of(find.page, find.size))
     }
 
     override fun getById(id:Long): Deposit? {
-        return depositRepository.findOne(id)
+        return depositRepository.findById(id).orElse(null)
     }
 
     override fun save(deposit:Deposit): Deposit {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/TokenServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/TokenServiceImpl.kt
@@ -25,17 +25,17 @@ class TokenServiceImpl: TokenService {
     }
 
     override fun update(token: Token) {
-        val e=tokenRepository.findOne(token.id)
+        val e=tokenRepository.findById(token.id).orElse(null)
         BasicUtils.copyPropertiesIgnoreNull(token,e)
         tokenRepository.save(e)
     }
 
     override fun del(id: Long) {
-        return tokenRepository.delete(id)
+        return tokenRepository.deleteById(id)
     }
 
     override fun getById(id:Long): Token? {
-        return tokenRepository.findOne(id)
+        return tokenRepository.findById(id).orElse(null)
     }
 
     override fun save(token:Token): Token {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/UserServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/UserServiceImpl.kt
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class UserServiceImpl: UserService {
 
     override fun getById(id:Long): User? {
-        return userRepository.findOne(id)
+        return userRepository.findById(id).orElse(null)
     }
 
     override fun save(user: User): User {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WaitCollectServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WaitCollectServiceImpl.kt
@@ -16,7 +16,7 @@ class WaitCollectServiceImpl: WaitCollectService {
         if (waitCollect.chainType == null) return
         val list = getByBean(waitCollect)
 
-        waitCollectRepository.delete(list)
+        waitCollectRepository.deleteAll(list)
     }
 
     override fun getByBean(waitCollect: WaitCollect): List<WaitCollect> {
@@ -34,7 +34,7 @@ class WaitCollectServiceImpl: WaitCollectService {
     }
 
     override fun getById(id:Long): WaitCollect? {
-        return waitCollectRepository.findOne(id)
+        return waitCollectRepository.findById(id).orElse(null)
     }
 
     override fun save(waitCollect:WaitCollect): WaitCollect {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WaitImportServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WaitImportServiceImpl.kt
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 class WaitImportServiceImpl: WaitImportService {
 
     override fun getById(id:Long): WaitImport? {
-        return waitImportRepository.findOne(id)
+        return waitImportRepository.findById(id).orElse(null)
     }
 
     override fun save(waitImport:WaitImport): WaitImport {
@@ -18,7 +18,7 @@ class WaitImportServiceImpl: WaitImportService {
     }
 
     override fun saveAll(waitImportList: List<WaitImport>): List<WaitImport> {
-        return waitImportRepository.save(waitImportList)
+        return waitImportRepository.saveAll(waitImportList)
     }
 
     override fun findAll(): List<WaitImport> {
@@ -26,7 +26,7 @@ class WaitImportServiceImpl: WaitImportService {
     }
 
     override fun deleteById(id: Long) {
-        waitImportRepository.delete(id)
+        waitImportRepository.deleteById(id)
     }
     
     @Autowired lateinit var waitImportRepository: WaitImportRepository

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WhiteServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WhiteServiceImpl.kt
@@ -15,7 +15,7 @@ import org.springframework.data.domain.PageRequest
 class WhiteServiceImpl: WhiteService {
 
     override fun getById(id:Long): White? {
-        return whiteRepository.findOne(id)
+        return whiteRepository.findById(id).orElse(null)
     }
 
     override fun save(white:White): White {
@@ -27,7 +27,7 @@ class WhiteServiceImpl: WhiteService {
         val entity = find.entity
         if (entity.ip != null)
             pre = pre.and(QWhite.white.ip.eq(entity.ip).or(QWhite.white.ip.eq("0.0.0.0")))
-        return whiteRepository.findAll(pre, PageRequest(find.page, find.size))
+        return whiteRepository.findAll(pre, PageRequest.of(find.page, find.size))
     }
 
     override fun findAll(): List<White> {
@@ -35,13 +35,13 @@ class WhiteServiceImpl: WhiteService {
     }
 
     override fun update(white: White) {
-        val e=whiteRepository.findOne(white.id)
+        val e=whiteRepository.findById(white.id).orElse(null)
         BasicUtils.copyPropertiesIgnoreNull(white,e)
         whiteRepository.save(e)
     }
 
     override fun del(id: Long) {
-        whiteRepository.delete(id)
+        whiteRepository.deleteById(id)
     }
 
     @Autowired lateinit var whiteRepository: WhiteRepository

--- a/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WithdrawServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/service/impl/WithdrawServiceImpl.kt
@@ -23,7 +23,7 @@ class WithdrawServiceImpl : WithdrawService {
             pre = pre.and(QWithdraw.withdraw.withdrawType.eq(entity.withdrawType))
         val sort = QSort(QWithdraw.withdraw.createdAt.desc())
 
-        return withdrawRepository.findAll(pre, PageRequest(find.page, find.size, sort))
+        return withdrawRepository.findAll(pre, PageRequest.of(find.page, find.size, sort))
     }
 
     override fun findAll(): List<Withdraw> {
@@ -40,7 +40,7 @@ class WithdrawServiceImpl : WithdrawService {
     }
 
     override fun getById(id: Long): Withdraw? {
-        return withdrawRepository.findOne(id)
+        return withdrawRepository.findById(id).orElse(null)
     }
 
     override fun save(withdraw: Withdraw): Withdraw {

--- a/wallet-common/src/main/kotlin/com/wallet/biz/xservice/impl/WalletXServiceImpl.kt
+++ b/wallet-common/src/main/kotlin/com/wallet/biz/xservice/impl/WalletXServiceImpl.kt
@@ -71,7 +71,7 @@ open class WalletXServiceImpl : WalletXService, LogService() {
                     txLogVo.type = TxLogDict.DEPOSIT
                     txLogVo
                 }
-                PageImpl(pageList.toList(), PageRequest(page, size), pageList.totalElements)
+                PageImpl(pageList.toList(), PageRequest.of(page, size), pageList.totalElements)
             }
             TxLogDict.WITHDRAW -> {
                 val find = PageEntity(Withdraw())
@@ -90,7 +90,7 @@ open class WalletXServiceImpl : WalletXService, LogService() {
                     txLogVo.type = TxLogDict.WITHDRAW
                     txLogVo
                 }
-                PageImpl(pageList.toList(), PageRequest(page, size), pageList.totalElements)
+                PageImpl(pageList.toList(), PageRequest.of(page, size), pageList.totalElements)
             }
             TxLogDict.COLLECT -> {
                 val find = PageEntity(Withdraw())
@@ -109,7 +109,7 @@ open class WalletXServiceImpl : WalletXService, LogService() {
                     txLogVo.type = TxLogDict.WITHDRAW
                     txLogVo
                 }
-                PageImpl(pageList.toList(), PageRequest(page, size), pageList.totalElements)
+                PageImpl(pageList.toList(), PageRequest.of(page, size), pageList.totalElements)
             }
             TxLogDict.SEND_FEE -> {
                 val find = PageEntity(Withdraw())
@@ -128,7 +128,7 @@ open class WalletXServiceImpl : WalletXService, LogService() {
                     txLogVo.type = TxLogDict.WITHDRAW
                     txLogVo
                 }
-                PageImpl(pageList.toList(), PageRequest(page, size), pageList.totalElements)
+                PageImpl(pageList.toList(), PageRequest.of(page, size), pageList.totalElements)
             }
             else -> throw BizException(ErrorCode.ERROR_PARAM)
         }

--- a/wallet-entity/build.gradle
+++ b/wallet-entity/build.gradle
@@ -1,9 +1,12 @@
+apply plugin: 'java-library'
+
 bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
-    implementation "com.querydsl:querydsl-jpa:$querydslVersion:jakarta"
-    implementation "com.querydsl:querydsl-sql-spring:$querydslVersion"
-    implementation "com.querydsl:querydsl-sql:$querydslVersion"
-    implementation "com.querydsl:querydsl-core:$querydslVersion"
+    api "com.querydsl:querydsl-jpa:$querydslVersion:jakarta"
+    api "com.querydsl:querydsl-sql-spring:$querydslVersion"
+    api "com.querydsl:querydsl-sql:$querydslVersion"
+    api "com.querydsl:querydsl-core:$querydslVersion"
+    api 'io.github.qyvlik:io.eblock.eos-eos4j:1.0.1'
 }

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/GetTransactionPo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/GetTransactionPo.kt
@@ -1,11 +1,10 @@
 package com.wallet.biz.domain.po
 
-import io.swagger.annotations.ApiModel
-import io.swagger.annotations.ApiModelProperty
+import io.swagger.v3.oas.annotations.media.Schema
 /** 
  * Created by pie on 2020/7/8 04: 34. 
  */
-@ApiModel
+@Schema
 class GetTransactionPo {
 
     var chain:String?=null
@@ -16,7 +15,7 @@ class GetTransactionPo {
 
     var type:Int?=null
 
-    @ApiModelProperty("合约地址")
+    @Schema(description = "合约地址")
     var tokenAddress:String?=null
 
     var limit:Int?=null

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/LoginPo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/LoginPo.kt
@@ -1,12 +1,11 @@
 package com.wallet.biz.domain.po
 
-import io.swagger.annotations.ApiModel
-import io.swagger.annotations.ApiModelProperty
+import io.swagger.v3.oas.annotations.media.Schema
 
-@ApiModel
+@Schema
 class LoginPo{
-    @ApiModelProperty("用户名")
+    @Schema(description = "用户名")
     var customerName:String?=null
-    @ApiModelProperty("密码")
+    @Schema(description = "密码")
     var password:String?=null
 }

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/RegisteredPo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/RegisteredPo.kt
@@ -1,27 +1,26 @@
 package com.wallet.biz.domain.po
 
-import io.swagger.annotations.ApiModel
-import io.swagger.annotations.ApiModelProperty
+import io.swagger.v3.oas.annotations.media.Schema
 
 /** 
  * Created by pie on 2019-03-08 17: 17. 
  */
-@ApiModel
+@Schema
 class RegisteredPo{
 
-    @ApiModelProperty("手机号(即用户名)",required = true)
+    @Schema(description = "手机号(即用户名)", requiredMode = Schema.RequiredMode.REQUIRED)
     var customerName:String?=null
 
-    @ApiModelProperty("登录密码",required = true)
+    @Schema(description = "登录密码", requiredMode = Schema.RequiredMode.REQUIRED)
     var password:String?=null
 
-    @ApiModelProperty("sms验证码",required = true)
+    @Schema(description = "sms验证码", requiredMode = Schema.RequiredMode.REQUIRED)
     var smsCode:Int?=null
 
-    @ApiModelProperty("邀请码",required = true)
+    @Schema(description = "邀请码", requiredMode = Schema.RequiredMode.REQUIRED)
     var inviteCode:String?=null
 
-    @ApiModelProperty("交易密码",required = true)
+    @Schema(description = "交易密码", requiredMode = Schema.RequiredMode.REQUIRED)
     var tradePassword:String?=null
 
 }

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/SendPo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/SendPo.kt
@@ -1,29 +1,28 @@
 package com.wallet.biz.domain.po
 
-import io.swagger.annotations.ApiModel
-import io.swagger.annotations.ApiModelProperty
+import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 
 /** 
  * Created by pie on 2019-04-12 09: 50. 
  */
-@ApiModel
+@Schema
 class SendPo{
 
-    @ApiModelProperty("发送者地址")
+    @Schema(description = "发送者地址")
     var from:String?=null
-    @ApiModelProperty("发送者地址code")
+    @Schema(description = "发送者地址code")
     var fromWalletCode:String?=null
 
-    @ApiModelProperty("接收者地址")
+    @Schema(description = "接收者地址")
     var to:String?=null
-    @ApiModelProperty("数量")
+    @Schema(description = "数量")
     var amount:BigDecimal?=null
-    @ApiModelProperty("币种类型  例: ETHEREUM")
+    @Schema(description = "币种类型  例: ETHEREUM")
     var chain:String?=null
-    @ApiModelProperty("代币类型 例: USDT")
+    @Schema(description = "代币类型 例: USDT")
     var symbol :String?=null
-    @ApiModelProperty("手续费价格 gas")
+    @Schema(description = "手续费价格 gas")
     var gas:Int?=null
 
     var data:String?=null

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/SignUsdtPo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/SignUsdtPo.kt
@@ -1,6 +1,5 @@
 package com.wallet.biz.domain.po
 
-import io.eblock.eos4j.api.vo.SignParam
 import org.consenlabs.tokencore.wallet.transaction.BitcoinTransaction
 import java.math.BigDecimal
 import java.util.ArrayList

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/TransferPo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/po/TransferPo.kt
@@ -1,12 +1,12 @@
 package com.wallet.biz.domain.po
 
-import io.swagger.annotations.ApiModel
+import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 
 /** 
  * Created by pie on 2019-03-08 17: 03. 
  */
-@ApiModel
+@Schema
 class TransferPo{
 
     var chainType:String?=null

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/vo/CustomerInfoVo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/vo/CustomerInfoVo.kt
@@ -1,18 +1,17 @@
 package com.wallet.biz.domain.vo
 
-import io.swagger.annotations.ApiModel
-import io.swagger.annotations.ApiModelProperty
+import io.swagger.v3.oas.annotations.media.Schema
 
 /** 
  * Created by pie on 2019-03-05 11: 55. 
  */
-@ApiModel
+@Schema
 class CustomerInfoVo {
 
-    @ApiModelProperty("用户名")
+    @Schema(description = "用户名")
     var customerName: String? = null
 
-    @ApiModelProperty("vip等级")
+    @Schema(description = "vip等级")
     var vipLevel:Int?=null
 
 

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/vo/DepositEosVo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/vo/DepositEosVo.kt
@@ -1,11 +1,11 @@
 package com.wallet.biz.domain.vo
 
-import io.swagger.annotations.ApiModel
+import io.swagger.v3.oas.annotations.media.Schema
 
 /** 
  * Created by pie on 2019-03-08 17: 00. 
  */
-@ApiModel
+@Schema
 class DepositEosVo{
 
     var depositAddress:String?=null

--- a/wallet-entity/src/main/kotlin/com/wallet/biz/domain/vo/TransferRecordVo.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/biz/domain/vo/TransferRecordVo.kt
@@ -1,11 +1,11 @@
 package com.wallet.biz.domain.vo
 
-import io.swagger.annotations.ApiModel
+import io.swagger.v3.oas.annotations.media.Schema
 
 /** 
  * Created by pie on 2019-03-08 16: 55. 
  */
-@ApiModel
+@Schema
 class TransferRecordVo{
 
 }

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/AddressAdminRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/AddressAdminRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.AddressAdmin
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface AddressAdminRepository : JpaRepository<AddressAdmin, Long>,
-    QueryDslPredicateExecutor<AddressAdmin>
+    QuerydslPredicateExecutor<AddressAdmin>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/AddressRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/AddressRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.Address
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface AddressRepository : JpaRepository<Address, Long>,
-    QueryDslPredicateExecutor<Address>
+    QuerydslPredicateExecutor<Address>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/BlockHeightRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/BlockHeightRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.BlockHeight
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface BlockHeightRepository : JpaRepository<BlockHeight, Long>,
-    QueryDslPredicateExecutor<BlockHeight>
+    QuerydslPredicateExecutor<BlockHeight>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/ConfigRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/ConfigRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.Config
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface ConfigRepository : JpaRepository<Config, Long>,
-    QueryDslPredicateExecutor<Config>
+    QuerydslPredicateExecutor<Config>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/DepositRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/DepositRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.Deposit
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface DepositRepository : JpaRepository<Deposit, Long>,
-    QueryDslPredicateExecutor<Deposit>
+    QuerydslPredicateExecutor<Deposit>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/TokenRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/TokenRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.Token
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface TokenRepository : JpaRepository<Token, Long>,
-    QueryDslPredicateExecutor<Token>
+    QuerydslPredicateExecutor<Token>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/UserRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/UserRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface UserRepository : JpaRepository<User, Long>,
-    QueryDslPredicateExecutor<User>
+    QuerydslPredicateExecutor<User>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/WaitCollectRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/WaitCollectRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.WaitCollect
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface WaitCollectRepository : JpaRepository<WaitCollect, Long>,
-    QueryDslPredicateExecutor<WaitCollect>
+    QuerydslPredicateExecutor<WaitCollect>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/WaitImportRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/WaitImportRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.WaitImport
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface WaitImportRepository : JpaRepository<WaitImport, Long>,
-    QueryDslPredicateExecutor<WaitImport>
+    QuerydslPredicateExecutor<WaitImport>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/WhiteRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/WhiteRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.White
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface WhiteRepository : JpaRepository<White, Long>,
-    QueryDslPredicateExecutor<White>
+    QuerydslPredicateExecutor<White>

--- a/wallet-entity/src/main/kotlin/com/wallet/repository/WithdrawRepository.kt
+++ b/wallet-entity/src/main/kotlin/com/wallet/repository/WithdrawRepository.kt
@@ -2,7 +2,7 @@ package com.wallet.repository
 
 import com.wallet.entity.domain.Withdraw
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.querydsl.QueryDslPredicateExecutor
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 
 interface WithdrawRepository : JpaRepository<Withdraw, Long>,
-    QueryDslPredicateExecutor<Withdraw>
+    QuerydslPredicateExecutor<Withdraw>

--- a/wallet-hsm/build.gradle
+++ b/wallet-hsm/build.gradle
@@ -8,6 +8,7 @@ mainClassName = "com.wallet.HsmApplicationKt"
 
 dependencies {
     implementation project(":wallet-entity")
+    implementation 'io.github.qyvlik:io.eblock.eos-eos4j:1.0.1'
 }
 
 jib {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the CI build failure reported in [actions/runs/23904371445](https://github.com/GalaxySciTech/java-wallet/actions/runs/23904371445/job/69709092070#step:6:129). The `wallet-entity:compileKotlin` task was failing due to multiple categories of unresolved references. This PR also fixes pre-existing compilation errors in `wallet-common`, `wallet-hsm`, `wallet-webapi`, and `wallet-task` modules that were masked because the build failed early on `wallet-entity`.

## Changes

### Swagger 2 → OpenAPI 3 Migration (wallet-entity)
- Replaced `io.swagger.annotations.ApiModel` / `ApiModelProperty` with `io.swagger.v3.oas.annotations.media.Schema` in:
  - `GetTransactionPo.kt`, `LoginPo.kt`, `RegisteredPo.kt`, `SendPo.kt`, `TransferPo.kt`
  - `CustomerInfoVo.kt`, `DepositEosVo.kt`, `TransferRecordVo.kt`

### QueryDSL Spring Data 3.x Fix (wallet-entity)
- Renamed `QueryDslPredicateExecutor` → `QuerydslPredicateExecutor` (lowercase 'dsl') across all 11 repository interfaces to match Spring Data 3.x API

### Dependency Resolution
- Added explicit `io.github.qyvlik:io.eblock.eos-eos4j:1.0.1` dependency to `wallet-entity` and `wallet-hsm` (transitive from tokencore via JitPack was not resolving)
- Added `commons-codec:commons-codec:1.16.0` and `org.bitcoinj:bitcoinj-core:0.14.7` to `wallet-common`
- Applied `java-library` plugin to `wallet-entity` and `wallet-common`, changed QueryDSL and project dependencies to `api` scope so transitive types are accessible to downstream modules

### Spring Data 2.x → 3.x API Migration (wallet-common)
- `repository.findOne(id)` → `repository.findById(id).orElse(null)` (15 occurrences)
- `repository.delete(id)` → `repository.deleteById(id)` (7 occurrences)
- `repository.delete(list)` → `repository.deleteAll(list)` (1 occurrence)
- `repository.save(list)` → `repository.saveAll(list)` (3 occurrences)
- `PageRequest(page, size)` → `PageRequest.of(page, size)` (6 occurrences)

### Other Fixes (wallet-common)
- `RestTemplateBuilder.connectTimeout()` → `.setConnectTimeout()` for Spring Boot 3.x
- Fixed `BizException` constructor mismatch in `PushComponent.kt`
- Replaced unavailable `ECKey.findRecoveryId()` with manual recovery ID computation in `TrxApi.kt` (bitcoinj 0.14.7 compatibility)
- Removed unused `SignParam` import from `SignUsdtPo.kt`

## Verification

Full project builds successfully with `./gradlew build -x test --no-daemon` — all modules compile cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d6eb8b6-7579-4de8-b357-59e065ef66ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d6eb8b6-7579-4de8-b357-59e065ef66ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

